### PR TITLE
Update readme.md to use recommended installation method for pnpm

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ npm install @kinde/management-api-js
 # yarn
 yarn add @kinde/management-api-js
 # pnpm
-pnpm install @kinde/management-api-js
+pnpm add @kinde/management-api-js
 ```
 
 ## Configuration


### PR DESCRIPTION
The docs for `pnpm` recommend using `pnpm add <dependency>` to add new dependencies to projects.

While `pnpm install <dependency>` does work, it might be good to keep instructions in line with their docs in case they decide to break installing in this way. (who know what will happen 😂)

https://pnpm.io/cli/add